### PR TITLE
Adding DoH bootstrapaddress

### DIFF
--- a/SecureFox.js
+++ b/SecureFox.js
@@ -199,6 +199,7 @@ user_pref("security.insecure_connection_text.enabled", true);
 // [1] https://nextdns.io
 // user_pref("network.trr.uri", "");
 // user_pref("network.trr.custom_uri", "");
+// user_pref("network.trr.bootstrapAddress", ""); /*Optional starting Firefox 74*/
 
 /******************************************************************************
  * SECTION: PASSWORDS                             *


### PR DESCRIPTION
As explained in this ghacks article : https://www.ghacks.net/2018/03/20/firefox-dns-over-https-and-a-worrying-shield-study/  
`network.trr.bootstrapAddress -- May set this to the IP of the URI under network.trr.uri to bypass using the native system resolver to look it up (default: none)`  
I would have posted nextdns.io previous suggested bootstrap address, but they removed from their web interface. It is referenced in their DoH cli client. https://github.com/nextdns/nextdns/blob/master/resolver/endpoint/doh.go

Also, according to another ghacks article, it is no longer necessary if `network.trr.mode` is set to 3. https://www.ghacks.net/2018/04/02/configure-dns-over-https-in-firefox/  
That's why I’ve added the optional point, as it could still be usefull for ESR releases builds.